### PR TITLE
Add pokemon renaming (nickname) function to web UI

### DIFF
--- a/listener.py
+++ b/listener.py
@@ -27,3 +27,6 @@ class Listener(object):
 
     def ping(self):
         return "pong"
+
+    def rename_pokemon(self, p_id, p_name, p_iv):
+        return self.api.rename_pokemon(p_id, p_name, p_iv)

--- a/pgoapi/pgoapi.py
+++ b/pgoapi/pgoapi.py
@@ -818,6 +818,18 @@ class PGoApi:
         for pokemons in caught_pokemon.values():
             for pokemon in pokemons:
                 self.log.info("%s", pokemon)
+                
+    def rename_pokemon(self, p_id, p_name, p_iv):
+        nickname = '{0}_{1}%'.format(p_name[0:8], int(float(p_iv)))
+        self.log.info("Renaming %s (ID=%s) to %s", p_name, p_id, nickname)
+        self.nickname_pokemon(pokemon_id=int(p_id),
+                              nickname=nickname)
+        res = self.call()
+        self.log.debug("Rename response: %s.", res)
+        if not res:
+            self.log.error("There were a problem responses for api call: %s. Can't rename!", res)
+            return False
+        return True
 
     def cleanup_pokemon(self, inventory_items=None):
         if not inventory_items:

--- a/pgoapi/pgoapi.py
+++ b/pgoapi/pgoapi.py
@@ -818,7 +818,7 @@ class PGoApi:
         for pokemons in caught_pokemon.values():
             for pokemon in pokemons:
                 self.log.info("%s", pokemon)
-                
+
     def rename_pokemon(self, p_id, p_name, p_iv):
         nickname = '{0}_{1}%'.format(p_name[0:8], int(float(p_iv)))
         self.log.info("Renaming %s (ID=%s) to %s", p_name, p_id, nickname)

--- a/templates/status.html
+++ b/templates/status.html
@@ -59,6 +59,7 @@
             <th style="{{options["ignore_move1"]}}">Move 1</th>
             <th style="{{options["ignore_move2"]}}">Move 2</th>
             <th style="{{options["ignore_transfer"]}}">Transfer</th>
+            <th style="{{options["ignore_rename"]}}">Rename</th>
           </thead>
           {% for pokemon in pokemons %}
           <tr id="{{pokemon.id}}">
@@ -81,6 +82,7 @@
               <td style="{{options["ignore_move1"]}}">{{attacks[pokemon.move_1]}}</td>
               <td style="{{options["ignore_move2"]}}">{{attacks[pokemon.move_2]}}</td>
               <td style="{{options["ignore_transfer"]}}"><a href="{{ url_for('transfer', username = username, p_id = pokemon.id)}}">Transfer</a></td>
+              <td style="{{options["ignore_rename"]}}"><a href="{{ url_for('rename', username = username, p_id = pokemon.id, p_name = pokemon.name, p_iv = pokemon.iv)}}">Rename</a></td>
           </tr>
           {% endfor %}
         </table>

--- a/web.py
+++ b/web.py
@@ -223,13 +223,15 @@ def transfer(username, p_id):
         flash("Failed!")
     return redirect(url_for('inventory', username=username))
 
+
 @app.route("/<username>/rename/<p_id>/<p_name>/<p_iv>")
 def rename(username, p_id, p_name, p_iv):
     c = get_api_rpc(username)
     try:
         if c.rename_pokemon(p_id, p_name, p_iv):
             flash('Renamed to {0}_{1}%'.format(p_name[0:8], int(float(p_iv))))
-        else: flash("Unable to rename")
+        else:
+            flash("Unable to rename")
     except:
         return jsonify(status=1, result='Error renaming Pokemon.')
     return redirect(url_for('status', username=username))

--- a/web.py
+++ b/web.py
@@ -223,6 +223,17 @@ def transfer(username, p_id):
         flash("Failed!")
     return redirect(url_for('inventory', username=username))
 
+@app.route("/<username>/rename/<p_id>/<p_name>/<p_iv>")
+def rename(username, p_id, p_name, p_iv):
+    c = get_api_rpc(username)
+    try:
+        if c.rename_pokemon(p_id, p_name, p_iv):
+            flash('Renamed to {0}_{1}%'.format(p_name[0:8], int(float(p_iv))))
+        else: flash("Unable to rename")
+    except:
+        return jsonify(status=1, result='Error renaming Pokemon.')
+    return redirect(url_for('status', username=username))
+
 
 @app.route("/<username>/snipe/<latlng>")
 def snipe(username, latlng):


### PR DESCRIPTION
Added feature in the web UI to let users rename their Pokemon (see #398).
Currently it renames the pokemon to "PokemonName_IV%" (where PokemonName is truncated to 8
chars), using the nickname proto. This is handy (at least for me) for when using bot account on phone as can see IV values in game.

Possible later additions:
- Get desired nickname from user instead of defaulting to PokemonName_IV%
- Add config option for auto-renaming newly caught Pokemon (as long as it isn't in the 'pokemon to release list'). I attempted to add this but kept getting 0 returned whenever I tried to get the pokemon ID, so this feature didn't end up in this commit.
