### PR TITLE
Proxy Support - Refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ You can create an alias for this by adding `alias pokecli='docker start poketrai
 Poketrainer supports:
  * HTTP/HTTPS Proxies (IP Authentication or Basic Authentication)
  * SOCKS5 Proxies
- * PTC accounts only
+ * PTC accounts Only
 
 To start Poketrainer with a proxy assigned, you need the `-p`/`--proxy` flag when running `pokecli.py`. Use the `proxy_ip:proxy_port` format
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ optional arguments:
   -e ENCRYPT_LIB, --encrypt-lib ENCRYPT_LIB
                         encrypt lib, libencrypt.so/encrypt.dll
   -d, --debug           Debug Mode
+  -p PROXY, --proxy PROXY
+                        Use Proxy, proxy_ip:port
 ```
 
 ### Web UI

--- a/README.md
+++ b/README.md
@@ -182,6 +182,27 @@ The container is now running in the foregorund, and can be stopped by using `Ctr
 You can create an alias for this by adding `alias pokecli='docker start poketrainer && docker attach poketrainer'` to ~/.bashrc.  	
 
 
+### Proxy Support
+Poketrainer supports:
+ * HTTP/HTTPS Proxies (IP Authentication or Basic Authentication)
+ * SOCKS5 Proxies
+ * PTC accounts only
+
+To start Poketrainer with a proxy assigned, you need the `-p`/`--proxy` flag when running `pokecli.py`. Use the `proxy_ip:proxy_port` format
+
+Examples:
+ * To start Poketrainer with a HTTP/HTTPS proxy:
+
+        python pokecli.py -i 0 -p 123.123.123.123:1234
+ * Basic Auth HTTP/HTTPS Proxy:
+
+        python pokecli.py -i 0 -p https://user:pass@123.123.123.123:1234
+ * SOCKS5 proxy:
+
+        python pokecli.py -i 0 -p socks5://123.123.123.123:1234 
+
+    If you get an error, run `pip install pysocks` to add support to SOCKS5 proxies.
+    
 ### What's working:
 What's working:
  * A lot of things. Check out the example config to see some of the features. Catching Lured pokemon, sniping, regular pokemon, multiple kinds of navigation (google maps, walking, driving, customized speed), a web ui, auto transfers, auto evolves, auto power ups, auto egg incubation, inventory managament, multiple account botting. And much more, README to be updated soon.
@@ -203,6 +224,7 @@ What's working:
 * [AHAAAAAAA](https://github.com/AHAAAAAAA/PokemonGo-Map) for parts of the s2sphere stuff
 * [beeedy](https://github.com/beeedy) for ability to transfer duplicate pokemon
 * [infinitewarp](https://github.com/infinitewarp) for introducing tox and cleaning up the code
+* [vmunich](https://github.com/vmunich) for implementing proxy support
 * And to anyone on the pokemongodev slack channel <3
 
 >>>>>>> super sketch but yolo

--- a/library/api/pgoapi/auth_google.py
+++ b/library/api/pgoapi/auth_google.py
@@ -46,7 +46,7 @@ class AuthGoogle(Auth):
 
         self._refresh_token = None
 
-    def user_login(self, username, password):
+    def user_login(self, username, password, proxy=None):
         self.log.info('Google User Login for: {}'.format(username))
 
         if not isinstance(username, six.string_types) or not isinstance(password, six.string_types):

--- a/library/api/pgoapi/pgoapi.py
+++ b/library/api/pgoapi/pgoapi.py
@@ -51,7 +51,7 @@ class PGoApi:
 
         self._auth_provider = None
         if provider is not None and ((username is not None and password is not None) or (oauth2_refresh_token is not None)):
-            self.set_authentication(provider, oauth2_refresh_token, username, password)
+            self.set_authentication(provider, oauth2_refresh_token, username, password, proxy=self._req_proxy)
 
         self.set_api_endpoint("pgorelease.nianticlabs.com/plfe")
 
@@ -60,11 +60,17 @@ class PGoApi:
         self._position_alt = position_alt
 
         self._signature_lib = None
+        self._req_proxy = None
+
+    def set_proxy(self, proxy):
+        self.log.debug('Set Proxy - Proxy: %s', proxy)
+        self._req_proxy = {"http" : proxy, "https" : proxy}
+        self.log.info('Using Proxy: %s', self._req_proxy)
 
     def set_logger(self, logger=None):
         self.log = logger or logging.getLogger(__name__)
 
-    def set_authentication(self, provider=None, oauth2_refresh_token=None, username=None, password=None):
+    def set_authentication(self, provider=None, oauth2_refresh_token=None, username=None, password=None, proxy=None):
         if provider == 'ptc':
             self._auth_provider = AuthPtc()
         elif provider == 'google':
@@ -79,7 +85,7 @@ class PGoApi:
         if oauth2_refresh_token is not None:
             self._auth_provider.set_refresh_token(oauth2_refresh_token)
         elif username is not None and password is not None:
-            self._auth_provider.user_login(username, password)
+            self._auth_provider.user_login(username, password, proxy)
         else:
             raise AuthException("Invalid Credential Input - Please provide username/password or an oauth2 refresh token")
 
@@ -106,7 +112,7 @@ class PGoApi:
         return self._auth_provider
 
     def create_request(self):
-        request = PGoApiRequest(self, self._position_lat, self._position_lng, self._position_alt)
+        request = PGoApiRequest(self, self._position_lat, self._position_lng, self._position_alt, self._req_proxy)
         return request
 
     def activate_signature(self, lib_path):
@@ -147,7 +153,7 @@ class PGoApi:
     """
     The login function is not needed anymore but still in the code for backward compatibility"
     """
-    def login(self, provider, username, password, lat=None, lng=None, alt=None, app_simulation=True):
+    def login(self, provider, username, password, proxy, lat=None, lng=None, alt=None, app_simulation=True):
 
         if lat is not None and lng is not None and alt is not None:
             self._position_lat = lat
@@ -155,7 +161,7 @@ class PGoApi:
             self._position_alt = alt
 
         try:
-            self.set_authentication(provider, username=username, password=password)
+            self.set_authentication(provider, username=username, password=password, proxy=proxy)
         except AuthException as e:
             self.log.error('Login process failed: %s', e)
             return False
@@ -181,7 +187,7 @@ class PGoApi:
 
 
 class PGoApiRequest:
-    def __init__(self, parent, position_lat, position_lng, position_alt):
+    def __init__(self, parent, position_lat, position_lng, position_alt, proxy):
         self.log = logging.getLogger(__name__)
 
         self.__parent__ = parent
@@ -196,6 +202,8 @@ class PGoApiRequest:
 
         self._req_method_list = []
 
+        self._req_proxy = proxy
+
     def call(self):
         if not self._req_method_list:
             raise EmptySubrequestChainException()
@@ -207,7 +215,7 @@ class PGoApiRequest:
             self.log.info('Not logged in')
             return NotLoggedInException()
 
-        request = RpcApi(self._auth_provider)
+        request = RpcApi(self._auth_provider, self._req_proxy)
 
         lib_path = self.__parent__.get_signature_lib()
         if lib_path is not None:

--- a/library/api/pgoapi/rpc_api.py
+++ b/library/api/pgoapi/rpc_api.py
@@ -58,7 +58,7 @@ class RpcApi:
     RPC_ID = 0
     START_TIME = 0
 
-    def __init__(self, auth_provider):
+    def __init__(self, auth_provider, req_proxy):
 
         self.log = logging.getLogger(__name__)
 
@@ -67,6 +67,7 @@ class RpcApi:
         self._session.verify = True
 
         self._auth_provider = auth_provider
+        self._req_proxy = req_proxy
 
         """ mystic unknown6 - revolved by PokemonGoDev """
         self._signature_gen = False
@@ -112,7 +113,7 @@ class RpcApi:
 
         request_proto_serialized = request_proto_plain.SerializeToString()
         try:
-            http_response = self._session.post(endpoint, data=request_proto_serialized)
+            http_response = self._session.post(endpoint, data=request_proto_serialized, proxies=self._req_proxy)
         except requests.exceptions.ConnectionError as e:
             raise ServerBusyOrOfflineException(e)
 

--- a/pokecli.py
+++ b/pokecli.py
@@ -47,6 +47,7 @@ def init_arguments():
                         help="Location. Only applies if an account was selected through config_index parameter")
     parser.add_argument("-e", "--encrypt_lib", help="encrypt lib, libencrypt.so/encrypt.dll", default="libencrypt.so")
     parser.add_argument("-d", "--debug", help="Debug Mode", action='store_true', default=False)
+    parser.add_argument("-p", "--proxy", help="Use Proxy, proxy_ip:port", default=None)
     arguments = parser.parse_args()
     return arguments.__dict__
 

--- a/poketrainer/poketrainer.py
+++ b/poketrainer/poketrainer.py
@@ -41,6 +41,7 @@ class Poketrainer(object):
         self.socket = None
         self.cli_args = args
         self.force_debug = args['debug']
+        self._req_proxy = None
 
         # timers, counters and triggers
         self.pokemon_caught = 0
@@ -166,11 +167,21 @@ class Poketrainer(object):
                 position = prev_location
             self.api.set_position(*position)
 
+            # set proxy if one was provided
+            if self.cli_args['proxy']:
+                self.api.set_proxy(self.cli_args['proxy'])
+                self.log.info('Using proxy: %s', self.cli_args['proxy'])
+
+            # proxies only work with ptc accounts at the moment!
+            if self.cli_args['proxy'] and self.config.auth_service != 'ptc':
+                self.log.error("Currently proxy only works with ptc accounts.")
+                quit()
+
             # retry login every 30 seconds if any errors
             self.log.info('Starting Login process...')
             login = False
             while not login:
-                login = self.api.login(self.config.auth_service, self.config.username, self.config.get_password())
+                login = self.api.login(self.config.auth_service, self.config.username, self.config.get_password(), proxy=self.cli_args['proxy'])
                 if not login:
                     self.log.error('Login error, retrying Login in 30 seconds')
                     self.sleep(30)


### PR DESCRIPTION
This PR reimplements proxy support accounting for the recent refactor.
### Proxy Support

Poketrainer supports:
- HTTP/HTTPS Proxies (IP Authentication or Basic Authentication)
- SOCKS5 Proxies
- PTC accounts only

To start Poketrainer with a proxy assigned, you need the `-p`/`--proxy` flag when running `pokecli.py`. Use the `proxy_ip:proxy_port` format

Examples:
- To start Poketrainer with a HTTP/HTTPS proxy:
  
  ```
  python pokecli.py -i 0 -p 123.123.123.123:1234
  ```
- Basic Auth HTTP/HTTPS Proxy:
  
  ```
  python pokecli.py -i 0 -p https://user:pass@123.123.123.123:1234
  ```
- SOCKS5 proxy:
  
  ```
  python pokecli.py -i 0 -p socks5://123.123.123.123:1234 
  ```
  
  If you get an error, run `pip install pysocks` to add support to SOCKS5 proxies.

At the moment I could only support PTC accounts because the API imports `gpsoauth` for google authentication. We can either include this library within Poketrainer, so I can edit its source to support proxies, or we can login on Google using the local IP, but after login, route all requests through the proxy. This is open for discussion.
