### PR TITLE
Add pysocks to requirements.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,6 @@ Examples:
 
         python pokecli.py -i 0 -p socks5://123.123.123.123:1234 
 
-    If you get an error, run `pip install pysocks` to add support to SOCKS5 proxies.
     
 ### What's working:
 What's working:

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ xxhash
 colorlog
 pylru
 python-dateutil
+pysocks


### PR DESCRIPTION
`Pysocks` adds support for SOCKS5 proxies to `requests`. I left it out of `requirements.txt` worrying that only a small number of users would actually use SOCKS5 proxies and I didn't want to clutter the script with barely used libs. 

I was advised to include it in `requeriments.txt`.
