### PR TITLE
lessen time output, dont care about date or milliseconds

### DIFF
--- a/helper/colorlogger.py
+++ b/helper/colorlogger.py
@@ -11,7 +11,7 @@ def create_logger(name, color='reset', log_level=logging.INFO, log_colors={
         'CRITICAL': 'red,bg_white',
 }):
     handler = colorlog.StreamHandler()
-    handler.setFormatter(colorlog.ColoredFormatter('%(log_color)s%(asctime)s %(' + color + ')s[%(module)10s] %(log_color)s[%(levelname)5s] %(' + color + ')s%(message)s',
+    handler.setFormatter(colorlog.ColoredFormatter('%(log_color)s%(asctime)s %(' + color + ')s[%(module)12s] %(log_color)s[%(levelname)5s] %(' + color + ')s%(message)s',
                                                    log_colors=log_colors, datefmt="%H:%M:%S"))
     log = colorlog.getLogger(name)
     log.propagate = False

--- a/helper/colorlogger.py
+++ b/helper/colorlogger.py
@@ -12,7 +12,7 @@ def create_logger(name, color='reset', log_level=logging.INFO, log_colors={
 }):
     handler = colorlog.StreamHandler()
     handler.setFormatter(colorlog.ColoredFormatter('%(log_color)s%(asctime)s %(' + color + ')s[%(module)10s] %(log_color)s[%(levelname)5s] %(' + color + ')s%(message)s',
-                                                   log_colors=log_colors))
+                                                   log_colors=log_colors, datefmt="%H:%M:%S"))
     log = colorlog.getLogger(name)
     log.propagate = False
     log.addHandler(handler)


### PR DESCRIPTION
everything lines up now and the time string doesnt take up half the screen
`20:42:45 [poke_catcher] [ INFO]`
`20:42:48 [ fort_walker] [ INFO]`
`20:42:50 [ poketrainer] [ INFO]`
