### PR TITLE
add some randomness to altitude

### DIFF
--- a/library/api/pgoapi/rpc_api.py
+++ b/library/api/pgoapi/rpc_api.py
@@ -180,7 +180,7 @@ class RpcApi:
         if player_position is not None:
             request.latitude, request.longitude, request.altitude = player_position
 
-        request.altitude = 8  # not as suspicious as 0
+        request.altitude = round(random.random() * 5 + 15, 2)  # not as suspicious as 0 or 8
 
         """ generate sub requests before signature generation """
         request = self._build_sub_requests(request, subrequests)


### PR DESCRIPTION
Before the big refactoring merge, we used to introduce randomness into our altitude so we would look a bit less bot-like.

See: https://github.com/j-e-k/poketrainer/blob/d579c3bb788ce5ac0e5ef405ecd4c967a6efdcf7/pgoapi/rpc_api.py#L182

At the time, we were sending an integer value between 1 and 5 inclusive.

My change brings back that concept, but I generate a float instead of an int because modern phone GPS data can produce altitude with a couple digits of precision. I've also shifted the base elevation to 15 m. So, it produces values between 15 and 20 m.
