### PR TITLE
Properly redirect RPC calls on status code 53

### DIFF
--- a/library/api/pgoapi/rpc_api.py
+++ b/library/api/pgoapi/rpc_api.py
@@ -365,6 +365,11 @@ class RpcApi:
         self.log.debug('Parsing sub RPC responses...')
         response_proto_dict['responses'] = {}
 
+        if response_proto_dict.get('status_code', 1) == 53:
+            exception = ServerApiEndpointRedirectException()
+            exception.set_redirected_endpoint(response_proto_dict['api_url'])
+            raise exception
+
         if 'returns' in response_proto_dict:
             del response_proto_dict['returns']
 


### PR DESCRIPTION
I'm transplanting fixes from the main pgoapi repo. In this case, this is a redo of https://github.com/keyphact/pgoapi/pull/63 which fixed https://github.com/keyphact/pgoapi/issues/47

> When the server returns status code 53, the API fails to properly parse the response, causing IndexError.
> 
> This raises a ServerApiEndpointRedirectException so that requests will use the new RPC url and be retried like they're supposed to.

This apparently happens when this error occurs:

```
list index out of range
Full stacktrace:
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/threading.py", line 783, in __bootstrap
    self.__bootstrap_inner()
  File "/usr/local/lib/python2.7/threading.py", line 810, in __bootstrap_inner
    self.run()
  File "/usr/local/lib/python2.7/threading.py", line 763, in run
    self.__target(*self.__args, **self.__kwargs)
  File "main.py", line 474, in scanPokemon
    response_dict = api.get_map_objects(latitude =coords[0], longitude = coords[1], since_timestamp_ms = timestamps, cell_id = cell_ids)
  File "/home/pokemap/pgoapi/pgoapi.py", line 129, in function
    return request.call()
  File "/home/pokemap/pgoapi/pgoapi.py", line 231, in call
    response = request.request(self._api_endpoint, self._req_method_list, self.get_position())
  File "/home/pokemap/pgoapi/rpc_api.py", line 140, in request
    response_dict = self._parse_main_response(response, subrequests)
  File "/home/pokemap/pgoapi/rpc_api.py", line 376, in _parse_main_response
    response_proto_dict = self._parse_sub_responses(response_proto, subrequests, response_proto_dict)
  File "/home/pokemap/pgoapi/rpc_api.py", line 394, in _parse_sub_responses
    request_entry = subrequests_list[i]
IndexError: list index out of range
```
