### PR TITLE
Add a sane API timeout.

### DIFF
--- a/library/api/pgoapi/rpc_api.py
+++ b/library/api/pgoapi/rpc_api.py
@@ -113,8 +113,8 @@ class RpcApi:
 
         request_proto_serialized = request_proto_plain.SerializeToString()
         try:
-            http_response = self._session.post(endpoint, data=request_proto_serialized, proxies=self._req_proxy)
-        except requests.exceptions.ConnectionError as e:
+            http_response = self._session.post(endpoint, data=request_proto_serialized, timeout=30, proxies=self._req_proxy)
+        except (requests.exceptions.Timeout, requests.exceptions.ConnectionError) as e:
             raise ServerBusyOrOfflineException(e)
 
         return http_response


### PR DESCRIPTION
I'm transplanting fixes from the main pgoapi repo. In this case, this is a redo of https://github.com/keyphact/pgoapi/pull/54

> Ensure a timeout is used otherwise api users may end up looking at the screen with no feedback.
