### PR TITLE
add tests around classic release method

### DIFF
--- a/tests/test_release_method_classic.py
+++ b/tests/test_release_method_classic.py
@@ -1,0 +1,208 @@
+import random
+import unittest
+from copy import deepcopy
+from unittest import skip, skipIf
+
+import six
+
+from poketrainer.pokedex import Pokedex
+from poketrainer.pokemon import Pokemon
+from poketrainer.release_methods.classic import ReleaseMethod as Classic
+
+mock_classic_config = {
+    'KEEP_POKEMON_NAMES': [
+        'EEVEE',
+    ],
+    'THROW_POKEMON_NAMES': [
+        'PIDGEY',
+    ],
+    'RELEASE_METHOD_CLASSIC': {
+        'KEEP_CP_OVER': 500,
+        'KEEP_IV_OVER': 80,
+    },
+    'MAX_SIMILAR_POKEMON': 4,
+    'MIN_SIMILAR_POKEMON': 2,
+}
+
+
+def mock_pokemon(pokemon_id, **kwargs):
+    return Pokemon(pokemon_data={
+        'pokemon_id': pokemon_id,
+        'id': kwargs.get('id', random.randint(10**19, 10**20)),
+        'cp': kwargs.get('cp', 10),
+        'favorite': kwargs.get('favorite', -1),
+        'individual_attack': kwargs.get('individual_attack', 5),
+        'individual_defence': kwargs.get('individual_defence', 5),
+        'individual_stamina': kwargs.get('individual_stamina', 5),
+    })
+
+
+class TestReleaseMethodClassic(unittest.TestCase):
+
+    def _get_pokemon_to_release(self, pokemon_id, expected_keep, expected_release, prefer=None):
+        pokemon_list = expected_release[:]
+        pokemon_list.extend(expected_keep[:])
+        config = deepcopy(mock_classic_config)
+        if prefer:
+            config['RELEASE_METHOD_CLASSIC']['PREFER'] = prefer
+        releaser = Classic(config=config)
+        if prefer:
+            releaser.prefer = prefer
+        to_release, to_keep = releaser.get_pokemon_to_release(pokemon_id, pokemon_list)
+        return to_release, to_keep
+
+    # TODO FIXME Stop skipping this test! Fix whatever is wrong with sort_key in py3.
+    @skipIf(six.PY3, 'not sure why python3 behaves differently here')
+    def test_get_pokemon_to_release__throw_after_min(self):
+
+        pokemon_id = Pokedex.PIDGEY
+
+        expected_keep = [
+            mock_pokemon(pokemon_id, cp=2000),
+            mock_pokemon(pokemon_id, cp=1999),
+        ]
+
+        expected_release = [
+            mock_pokemon(pokemon_id, cp=1998),
+            mock_pokemon(pokemon_id, cp=1500),
+            mock_pokemon(pokemon_id, cp=30),
+            mock_pokemon(pokemon_id, cp=20),
+            mock_pokemon(pokemon_id, cp=10),
+        ]
+
+        to_release, to_keep = self._get_pokemon_to_release(pokemon_id, expected_keep, expected_release)
+        self.assertListEqual(to_keep, expected_keep)
+        self.assertListEqual(to_release, expected_release)
+
+    # TODO FIXME Stop skipping this test! Fix whatever is wrong with sort_key in py3.
+    @skipIf(six.PY3, 'not sure why python3 behaves differently here')
+    def test_get_pokemon_to_release__keep_up_to_max(self):
+
+        pokemon_id = Pokedex.EEVEE
+
+        # TODO FIXME This looks like a bug. We should only keep 4!
+        expected_keep = [
+            mock_pokemon(pokemon_id, cp=2000),
+            mock_pokemon(pokemon_id, cp=1999),
+            mock_pokemon(pokemon_id, cp=30),
+            mock_pokemon(pokemon_id, cp=20),
+            mock_pokemon(pokemon_id, cp=15),
+        ]
+
+        expected_release = [
+            mock_pokemon(pokemon_id, cp=12),
+            mock_pokemon(pokemon_id, cp=10),
+        ]
+
+        to_release, to_keep = self._get_pokemon_to_release(pokemon_id, expected_keep, expected_release)
+        self.assertListEqual(to_keep, expected_keep)
+        self.assertListEqual(to_release, expected_release)
+
+    def test_get_pokemon_to_release__always_keep_favorite(self):
+
+        pokemon_id = Pokedex.EEVEE
+
+        expected_keep = [
+            mock_pokemon(pokemon_id, favorite=1, cp=2000),
+            mock_pokemon(pokemon_id, favorite=1, cp=1999),
+            mock_pokemon(pokemon_id, favorite=1, cp=30),
+            mock_pokemon(pokemon_id, favorite=1, cp=20),
+            mock_pokemon(pokemon_id, favorite=1, cp=15),
+            mock_pokemon(pokemon_id, favorite=1, cp=12),
+            mock_pokemon(pokemon_id, favorite=1, cp=10),
+            mock_pokemon(pokemon_id, favorite=1, cp=6),
+            mock_pokemon(pokemon_id, favorite=1, cp=1),
+        ]
+
+        expected_release = [
+        ]
+
+        to_release, to_keep = self._get_pokemon_to_release(pokemon_id, expected_keep, expected_release)
+        self.assertListEqual(to_keep, expected_keep)
+        self.assertListEqual(to_release, expected_release)
+
+    def test_get_pokemon_to_release__keep_min_best_cp(self):
+
+        pokemon_id = Pokedex.RATTATA
+
+        expected_keep = [
+            mock_pokemon(pokemon_id, cp=2000),
+            mock_pokemon(pokemon_id, cp=1999),
+        ]
+
+        expected_release = [
+            mock_pokemon(pokemon_id, cp=30),
+            mock_pokemon(pokemon_id, cp=20),
+            mock_pokemon(pokemon_id, cp=15),
+            mock_pokemon(pokemon_id, cp=12),
+            mock_pokemon(pokemon_id, cp=10),
+            mock_pokemon(pokemon_id, cp=6),
+            mock_pokemon(pokemon_id, cp=1),
+        ]
+
+        to_release, to_keep = self._get_pokemon_to_release(pokemon_id, expected_keep, expected_release)
+        self.assertListEqual(to_keep, expected_keep)
+        self.assertListEqual(to_release, expected_release)
+
+    def test_get_pokemon_to_release__keep_min_best_iv(self):
+
+        pokemon_id = Pokedex.RATTATA
+
+        expected_keep = [
+            mock_pokemon(pokemon_id, individual_attack=15),
+            mock_pokemon(pokemon_id, individual_attack=14),
+        ]
+
+        expected_release = [
+            mock_pokemon(pokemon_id, individual_attack=13),
+            mock_pokemon(pokemon_id, individual_attack=12),
+            mock_pokemon(pokemon_id, individual_attack=6),
+            mock_pokemon(pokemon_id, individual_attack=1),
+        ]
+
+        to_release, to_keep = self._get_pokemon_to_release(pokemon_id, expected_keep, expected_release)
+        self.assertListEqual(to_keep, expected_keep)
+        self.assertListEqual(to_release, expected_release)
+
+    def test_get_pokemon_to_release__keep_min_prefer_cp(self):
+
+        pokemon_id = Pokedex.RATTATA
+
+        expected_keep = [
+            mock_pokemon(pokemon_id, cp=2000, individual_attack=1),
+            mock_pokemon(pokemon_id, individual_attack=14),
+        ]
+
+        expected_release = [
+            mock_pokemon(pokemon_id, individual_attack=13),
+            mock_pokemon(pokemon_id, individual_attack=12),
+            mock_pokemon(pokemon_id, individual_attack=6),
+            mock_pokemon(pokemon_id, individual_attack=1),
+        ]
+
+        to_release, to_keep = self._get_pokemon_to_release(pokemon_id, expected_keep, expected_release)
+        self.assertListEqual(to_keep, expected_keep)
+        self.assertListEqual(to_release, expected_release)
+
+    # TODO FIXME Stop skipping this test! Fix whatever is wrong with sort_key.
+    @skip("something is wrong with the ternary statement that sets sort_key")
+    def test_get_pokemon_to_release__keep_min_prefer_iv_also_keep_cp_over(self):
+
+        pokemon_id = Pokedex.RATTATA
+
+        expected_keep = [
+            mock_pokemon(pokemon_id, cp=50, individual_attack=14),
+            mock_pokemon(pokemon_id, cp=90, individual_attack=13),
+            mock_pokemon(pokemon_id, cp=2000, individual_attack=1),
+        ]
+
+        expected_release = [
+            mock_pokemon(pokemon_id, individual_attack=12),
+            mock_pokemon(pokemon_id, individual_attack=6),
+            mock_pokemon(pokemon_id, cp=100, individual_attack=1),
+            mock_pokemon(pokemon_id, individual_attack=1),
+        ]
+
+        to_release, to_keep = self._get_pokemon_to_release(pokemon_id, expected_keep, expected_release, prefer='IV')
+        self.assertListEqual(to_keep, expected_keep)
+        self.assertListEqual(to_release, expected_release)


### PR DESCRIPTION
We're need better test coverage, especially around the complicated logic. I think I've already exposed a couple of bugs with this new test, and I'll be fixing them in a later PR.

Also, I expect this to fail on py3 builds until https://github.com/j-e-k/poketrainer/pull/561 gets merged.
