### PR TITLE
fix classic release sorting; fixes j-e-k/poketrainer/#564

### DIFF
--- a/poketrainer/release_methods/classic.py
+++ b/poketrainer/release_methods/classic.py
@@ -19,7 +19,11 @@ class ReleaseMethod(base.ReleaseMethod):
         self.max_similar_pokemon = self.config.get('MAX_SIMILAR_POKEMON', 999)
         self.min_similar_pokemon = self.config.get('MIN_SIMILAR_POKEMON', 1)
 
-        self.sort_key = (lambda x: (x.cp, x.iv)) if (self.prefer == 'CP') else (lambda x: (x.iv, x.cp))
+        # yes, this *could* be a one-liner, but keep it separate for readability
+        if self.prefer == 'CP':
+            self.sort_key = lambda x: (x.cp, x.iv)
+        else:
+            self.sort_key = lambda x: (x.iv, x.cp)
 
     def get_pokemon_to_release(self, pokemon_id, pokemons):
         pokemon_to_release = []

--- a/tests/test_release_method_classic.py
+++ b/tests/test_release_method_classic.py
@@ -1,7 +1,7 @@
 import random
 import unittest
 from copy import deepcopy
-from unittest import skip, skipIf
+from unittest import skipIf
 
 import six
 
@@ -184,8 +184,6 @@ class TestReleaseMethodClassic(unittest.TestCase):
         self.assertListEqual(to_keep, expected_keep)
         self.assertListEqual(to_release, expected_release)
 
-    # TODO FIXME Stop skipping this test! Fix whatever is wrong with sort_key.
-    @skip("something is wrong with the ternary statement that sets sort_key")
     def test_get_pokemon_to_release__keep_min_prefer_iv_also_keep_cp_over(self):
 
         pokemon_id = Pokedex.RATTATA


### PR DESCRIPTION
Fixes https://github.com/j-e-k/poketrainer/issues/564 and reenables the skipped test.
