### PR TITLE
Avoid `None` as a redundant second argument to `dict.get()`

### DIFF
--- a/poketrainer/evolve.py
+++ b/poketrainer/evolve.py
@@ -55,7 +55,7 @@ class Evolve(object):
 
     def is_pokemon_eligible_for_evolution(self, pokemon):
         candy_have = self.parent.inventory.pokemon_candy.get(int(pokemon.family_id), -1)
-        candy_needed = self.parent.config.pokemon_evolution.get(pokemon.pokemon_id, None)
+        candy_needed = self.parent.config.pokemon_evolution.get(pokemon.pokemon_id)
         in_keep_list = pokemon.pokemon_id in self.parent.config.keep_pokemon_ids
         is_favorite = pokemon.is_favorite
         in_evolution_list = pokemon.pokemon_id in self.parent.config.pokemon_evolution

--- a/poketrainer/location.py
+++ b/poketrainer/location.py
@@ -108,7 +108,7 @@ def filtered_forts(starting_location, origin, forts, proximity, visited_forts={}
 
 
 def is_active_pokestop(fort, visited_forts, starting_location, proximity):
-    is_active_fort = fort.get('type', None) == 1 and ("enabled" in fort or 'lure_info' in fort) and fort.get(
+    is_active_fort = fort.get('type') == 1 and ("enabled" in fort or 'lure_info' in fort) and fort.get(
         'cooldown_complete_timestamp_ms', -1) < time() * 1000
     if proximity and proximity > 0:
         return is_active_fort and fort['id'] not in visited_forts and distance_in_meters(starting_location, (


### PR DESCRIPTION
Issue found by running poketrainer through quantifiedcode.

Issue type: [Avoid `None` as a redundant second argument to `dict.get()`](https://www.quantifiedcode.com/app/issue_class/swQ4yi5C)
